### PR TITLE
Add Global Workflow support

### DIFF
--- a/src/emcenvchainer/config.py
+++ b/src/emcenvchainer/config.py
@@ -12,12 +12,27 @@ class Config:
     
     def _get_builtin_config(self) -> Dict:
         """Get built-in configuration."""
+
+
         return {
             "spack_repository": {
                 "base_url": "https://github.com/JCSDA/spack.git",
                 "packages_path": "var/spack/repos/builtin/packages",
                 "custom_repo_name": "envrepo",
                 "branch": "spack-stack-dev"
+            },
+            "applications": {
+                "ufs_weather_model": {
+                    "name": "UFS Weather Model",
+                    "common_module_url": "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_common.lua",
+                    "install_path_regex": r'prepend_path\("MODULEPATH",\s*"([^"]+)modulefiles/Core.?"\)'
+                },
+                "global_workflow": {
+                    "name": "Global Workflow",
+                    "package_versions_url": "https://raw.githubusercontent.com/NOAA-EMC/global-workflow/develop/versions/spack.ver",
+                    "package_versions_format": "shell_exports",
+                    "install_path_regex": r'prepend_path\("MODULEPATH",\s*"([^"]+)modulefiles/Core.?"\)'
+                }
             },
             "platforms": {
                 "ursa": {
@@ -27,13 +42,16 @@ class Config:
                     "cpu_target": "zen3",
                     "model_applications": {
                         "ufs_weather_model": {
-                            "name": "UFS Weather Model",
                             "module_url_templates": [
                                 "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_ursa.intelllvm.lua",
                                 "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_ursa.gnu.lua"
-                            ],
-                            "common_module_url": "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_common.lua",
-                            "install_path_regex": r'prepend_path\("MODULEPATH",\s*"([^"]+)modulefiles/Core.?"\)'
+                            ]
+                        },
+                        "global_workflow": {
+                            "module_url_templates": [
+                                "https://raw.githubusercontent.com/NOAA-EMC/global-workflow/develop/modulefiles/gw_setup.ursa.lua",
+                                "https://raw.githubusercontent.com/NOAA-EMC/global-workflow/develop/modulefiles/gw_run.ursa.lua"
+                            ]
                         }
                     }
                 },
@@ -43,12 +61,16 @@ class Config:
                     "hostname_patterns": [r"Orion-login.*\.HPC.MsState.Edu"],
                     "model_applications": {
                         "ufs_weather_model": {
-                            "name": "UFS Weather Model",
                             "module_url_templates": [
                                 "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_orion.intelllvm.lua",
                             ],
-                            "common_module_url": "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_common.lua",
-                            "install_path_regex": r'prepend_path\("MODULEPATH",\s*"([^"]+)modulefiles/Core.?"\)'                        }
+                        },
+                        "global_workflow": {
+                            "module_url_templates": [
+                                "https://raw.githubusercontent.com/NOAA-EMC/global-workflow/develop/modulefiles/gw_setup.orion.lua",
+                                "https://raw.githubusercontent.com/NOAA-EMC/global-workflow/develop/modulefiles/gw_run.orion.lua"
+                            ]
+                        }
                     }
                 },
                 "hercules": {
@@ -57,13 +79,17 @@ class Config:
                     "hostname_patterns": [r"Hercules-login.*\.HPC.MsState.Edu"],
                     "model_applications": {
                         "ufs_weather_model": {
-                            "name": "UFS Weather Model",
                             "module_url_templates": [
                                 "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_hercules.intelllvm.lua",
                                 "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_hercules.gnu.lua"
-                            ],
-                            "common_module_url": "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_common.lua",
-                            "install_path_regex": r'prepend_path\("MODULEPATH",\s*"([^"]+)modulefiles/Core.?"\)'                        }
+                            ]
+                        },
+                        "global_workflow": {
+                            "module_url_templates": [
+                                "https://raw.githubusercontent.com/NOAA-EMC/global-workflow/develop/modulefiles/gw_setup.hercules.lua",
+                                "https://raw.githubusercontent.com/NOAA-EMC/global-workflow/develop/modulefiles/gw_run.hercules.lua"
+                            ]
+                        }
                     }
                 },
                 "jet": {
@@ -72,12 +98,10 @@ class Config:
                     "hostname_patterns": [".+.jet.boulder.rdhpcs.noaa.gov"],
                     "model_applications": {
                         "ufs_weather_model": {
-                            "name": "UFS Weather Model",
                             "module_url_templates": [
                                 "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_jet.intel.lua",
                             ],
-                            "common_module_url": "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_common.lua",
-                            "install_path_regex": r'prepend_path\("MODULEPATH",\s*"([^"]+)modulefiles/Core.?"\)'                        }
+                        }
                     }
                 },
                 "gaea-c5": {
@@ -86,12 +110,10 @@ class Config:
                     "hostname_patterns": ["gaea5[1-8].ncrc.gov"],
                     "model_applications": {
                         "ufs_weather_model": {
-                            "name": "UFS Weather Model",
                             "module_url_templates": [
                                 "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_gaeac5.intel.lua"
-                            ],
-                            "common_module_url": "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_common.lua",
-                            "install_path_regex": r'prepend_path\("MODULEPATH",\s*"([^"]+)modulefiles/Core.?"\)'                        }
+                            ]
+                        }
                     }
                 },
                 "gaea-c6": {
@@ -100,12 +122,16 @@ class Config:
                     "hostname_patterns": ["gaea6[0-8].ncrc.gov"],
                     "model_applications": {
                         "ufs_weather_model": {
-                            "name": "ufs weather model",
                             "module_url_templates": [
                                 "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_gaeac6.intel.lua",
-                            ],
-                            "common_module_url": "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_common.lua",
-                            "install_path_regex": r'prepend_path\("MODULEPATH",\s*"([^"]+)modulefiles/Core.?"\)'                        }
+                            ]
+                        },
+                        "global_workflow": {
+                            "module_url_templates": [
+                                "https://raw.githubusercontent.com/NOAA-EMC/global-workflow/develop/modulefiles/gw_setup.gaeac6.lua",
+                                "https://raw.githubusercontent.com/NOAA-EMC/global-workflow/develop/modulefiles/gw_run.gaeac6.lua"
+                            ]
+                        }
                     }
                 },
                 "acorn": {
@@ -114,12 +140,16 @@ class Config:
                     "hostname_patterns": ["a.*.wcoss2.ncep.noaa.gov"],
                     "model_applications": {
                         "ufs_weather_model": {
-                            "name": "ufs weather model",
                             "module_url_templates": [
                                 "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_acorn.intel.lua",
-                            ],
-                            "common_module_url": "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_common.lua",
-                            "install_path_regex": r'prepend_path\("MODULEPATH",\s*"([^"]+)modulefiles/Core.?"\)'                        }
+                            ]
+                        },
+                        "global_workflow": {
+                            "module_url_templates": [
+                                "https://raw.githubusercontent.com/NOAA-EMC/global-workflow/develop/modulefiles/gw_setup.wcoss2.lua",
+                                "https://raw.githubusercontent.com/NOAA-EMC/global-workflow/develop/modulefiles/gw_run.wcoss2.lua"
+                            ]
+                        }
                     }
                 },
             },
@@ -139,3 +169,7 @@ class Config:
     def get_platforms(self) -> Dict:
         """Get platform configurations."""
         return self.get("platforms", {})
+
+    def get_applications(self) -> Dict:
+        """Get application configurations."""
+        return self.get("applications", {})

--- a/src/emcenvchainer/config.py
+++ b/src/emcenvchainer/config.py
@@ -24,11 +24,13 @@ class Config:
             "applications": {
                 "ufs_weather_model": {
                     "name": "UFS Weather Model",
+                    "spack_metapackage": "ufs-weather-model-env",
                     "common_module_url": "https://raw.githubusercontent.com/ufs-community/ufs-weather-model/develop/modulefiles/ufs_common.lua",
                     "install_path_regex": r'prepend_path\("MODULEPATH",\s*"([^"]+)modulefiles/Core.?"\)'
                 },
                 "global_workflow": {
                     "name": "Global Workflow",
+                    "spack_metapackage": "global-workflow-env",
                     "package_versions_url": "https://raw.githubusercontent.com/NOAA-EMC/global-workflow/develop/versions/spack.ver",
                     "package_versions_format": "shell_exports",
                     "install_path_regex": r'prepend_path\("MODULEPATH",\s*"([^"]+)modulefiles/Core.?"\)'

--- a/src/emcenvchainer/model_apps.py
+++ b/src/emcenvchainer/model_apps.py
@@ -1,5 +1,6 @@
 """Model application management."""
 
+import copy
 import os
 import re
 import requests
@@ -257,12 +258,24 @@ class ModelApplication:
             return base_name.title()
 
     def get_upgradable_packages(self) -> List[Dict]:
-        """Get list of upgradable packages from the common module file.
+        """Get list of upgradable packages from configured version sources.
         
         Returns:
             List of dictionaries with package name and current version
         """
-        # Return empty list if no common module URL is defined
+        package_versions_url = self.config.get("package_versions_url")
+        if package_versions_url:
+            response = requests.get(package_versions_url, timeout=30)
+            response.raise_for_status()
+            package_versions_content = response.text
+
+            versions_format = self.config.get("package_versions_format", "shell_exports")
+            if versions_format == "shell_exports":
+                return self._parse_shell_export_versions(package_versions_content)
+
+            raise RuntimeError(f"Unsupported package_versions_format: {versions_format}")
+
+        # Return empty list if no Lua common module URL is defined
         common_module_url = self.config.get("common_module_url")
         if not common_module_url:
             return []
@@ -324,6 +337,30 @@ class ModelApplication:
         
         return unique_packages
 
+    def _parse_shell_export_versions(self, content: str) -> List[Dict]:
+        """Parse shell export package versions from files like versions/spack.ver."""
+        upgradable_packages = []
+
+        for match in re.finditer(r'^\s*export\s+([a-zA-Z0-9_]+)_ver(?:sion)?\s*=\s*"?([^"\s#]+)"?', content, re.MULTILINE):
+            package_name = match.group(1).lower().replace("_", "-")
+            version = match.group(2)
+
+            if self._is_valid_upgradable_package(package_name, version):
+                upgradable_packages.append({
+                    "name": package_name,
+                    "version": version,
+                })
+
+        # Remove duplicates by package name while preserving order.
+        seen = set()
+        unique_packages = []
+        for pkg in upgradable_packages:
+            if pkg["name"] not in seen:
+                seen.add(pkg["name"])
+                unique_packages.append(pkg)
+
+        return unique_packages
+
     def _handle_simple_load_version_pattern(self, match, module_content):
         """Handle load("package/version") patterns for upgradable packages."""
         package_name = match.group(1).lower()
@@ -371,15 +408,17 @@ class ModelApplication:
 class ModelApplicationManager:
     """Manages model applications for a platform."""
     
-    def __init__(self, platform_config: Dict, platform_name: str):
+    def __init__(self, platform_config: Dict, platform_name: str, applications_config: Optional[Dict] = None):
         """Initialize model application manager.
         
         Args:
             platform_config: Platform configuration
             platform_name: Platform name
+            applications_config: Global application configuration defaults
         """
         self.platform_config = platform_config
         self.platform_name = platform_name
+        self.applications_config = applications_config or {}
         self._applications = None
     
     @property
@@ -390,8 +429,15 @@ class ModelApplicationManager:
             app_configs = self.platform_config.get("model_applications", {})
             
             for app_name, app_config in app_configs.items():
-                app = ModelApplication(app_name, app_config, self.platform_name)
+                merged_app_config = self._merge_application_config(app_name, app_config)
+                app = ModelApplication(app_name, merged_app_config, self.platform_name)
                 self._applications.append(app)
         
         return self._applications
+
+    def _merge_application_config(self, app_name: str, platform_app_config: Dict) -> Dict:
+        """Merge global application defaults with platform-specific overrides."""
+        base_config = copy.deepcopy(self.applications_config.get(app_name, {}))
+        base_config.update(platform_app_config)
+        return base_config
 

--- a/src/emcenvchainer/spack_manager.py
+++ b/src/emcenvchainer/spack_manager.py
@@ -11,7 +11,7 @@ import threading
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from ruamel.yaml import YAML
 
@@ -1483,9 +1483,28 @@ class SpackManager:
             Dictionary mapping package names to their info dictionaries with 'version', 'variants', 'compiler_flags', and 'external' keys
         """
         package_info = {}
+        package_candidates: Dict[str, List[Dict[str, str]]] = {}
         
         try:
             SPACK_STACK_DIR = os.path.abspath(os.path.join(upstream_env_path, "../../"))
+            requested_versions = {
+                pkg["name"]: pkg["current_version"]
+                for pkg in packages
+                if pkg.get("name") and pkg.get("current_version")
+            }
+
+            metapackages = sorted({
+                str(pkg.get("application_metapackage", "")).strip()
+                for pkg in packages
+                if str(pkg.get("application_metapackage", "")).strip()
+            })
+
+            metapackage_tie_breakers: Dict[str, List[Dict[str, str]]] = {}
+            for metapackage in metapackages:
+                deps = self._get_metapackage_dependency_candidates(upstream_env_path, metapackage)
+                for dep_name, dep_candidates in deps.items():
+                    metapackage_tie_breakers.setdefault(dep_name, []).extend(dep_candidates)
+
             # Get ALL packages with version, variants, compiler flags, and external status
             result = self._run_spack_command([
                 '-e', str(upstream_env_path), 
@@ -1504,68 +1523,145 @@ class SpackManager:
                     continue
                     
                 try:
-                    # Parse the output format: name:VERSION:version:VARIANTS:variants:FLAGS:compiler_flags:EXTERNAL:external
-                    parts = line.strip().split(':VERSION:')
-                    if len(parts) != 2:
+                    parsed = self._parse_upstream_find_line(line)
+                    if not parsed:
                         continue
-                        
-                    package_name = parts[0]
-                    rest = parts[1]
-                    
-                    # Split on :VARIANTS:, :FLAGS:, and :EXTERNAL:
-                    if ':VARIANTS:' not in rest or ':FLAGS:' not in rest or ':EXTERNAL:' not in rest:
-                        continue
-                    
-                    version_part, rest = rest.split(':VARIANTS:', 1)
-                    variants_part, rest = rest.split(':FLAGS:', 1)
-                    compiler_flags_part, external_part = rest.split(':EXTERNAL:', 1)
-                    
-                    version = version_part.strip()
-                    variants = variants_part.strip()
-                    compiler_flags = compiler_flags_part.strip()
-                    is_external = external_part.strip().lower() == 'true'
+
+                    package_name = parsed["name"]
+                    version = parsed["version"]
+                    variants = parsed["variants"]
+                    compiler_flags = parsed["compiler_flags"]
+                    is_external = parsed["is_external"]
                     
                     # Skip external packages
                     if is_external:
                         if self.logger:
                             self.logger.info(f"Skipping external package from upstream: {package_name}")
                         continue
-                    
-                    # Remove patches from variants
-                    variants = re.sub(r"patches=[\w,]+", "", variants).strip()
-                    
-                    # Store info for this package
-                    package_info[package_name] = {}
-                    
-                    if variants:
-                        package_info[package_name]['variants'] = variants
-                    
-                    if compiler_flags:
-                        package_info[package_name]['compiler_flags'] = compiler_flags
-                    
-                    # Check if this package is in the packages list being updated
-                    # If so, use version from modulefile in case of multiple versions in upstream env
-                    for pkg in packages:
-                        if pkg['name'] == package_name and 'current_version' in pkg:
-                            package_info[package_name]['version'] = pkg['current_version']
-                            break
-                    else:
-                        # Not in update list, use upstream version
-                        package_info[package_name]['version'] = version
-                    
-                    if self.logger:
-                        self.logger.info(f"Found upstream info for {package_name}: version={version}, variants={variants}, compiler_flags={compiler_flags}")
+
+                    package_candidates.setdefault(package_name, []).append({
+                        "version": version,
+                        "variants": variants,
+                        "compiler_flags": compiler_flags,
+                    })
                             
                 except Exception as e:
                     if self.logger:
                         self.logger.warning(f"Error parsing package info line '{line}': {e}")
                     continue
+
+            for package_name, candidates in package_candidates.items():
+                selected = candidates[-1]
+
+                # Tie-break on metapackage dependency concrete specs, when available.
+                if len(candidates) > 1 and package_name in metapackage_tie_breakers:
+                    dep_candidates = metapackage_tie_breakers[package_name]
+                    matched = [
+                        candidate
+                        for candidate in candidates
+                        if any(
+                            candidate["version"] == dep_candidate["version"] and
+                            candidate["variants"] == dep_candidate["variants"] and
+                            candidate["compiler_flags"] == dep_candidate["compiler_flags"]
+                            for dep_candidate in dep_candidates
+                        )
+                    ]
+                    if matched:
+                        selected = matched[-1]
+                        if self.logger:
+                            self.logger.info(
+                                f"Tie-break via metapackage for {package_name}: "
+                                f"selected version={selected['version']}, variants={selected['variants']}, "
+                                f"compiler_flags={selected['compiler_flags']}"
+                            )
+
+                package_info[package_name] = {}
+
+                if selected.get("variants"):
+                    package_info[package_name]["variants"] = selected["variants"]
+
+                if selected.get("compiler_flags"):
+                    package_info[package_name]["compiler_flags"] = selected["compiler_flags"]
+
+                if package_name in requested_versions:
+                    package_info[package_name]["version"] = requested_versions[package_name]
+                else:
+                    package_info[package_name]["version"] = selected["version"]
+
+                if self.logger:
+                    self.logger.info(
+                        f"Found upstream info for {package_name}: "
+                        f"version={package_info[package_name]['version']}, "
+                        f"variants={package_info[package_name].get('variants', '')}, "
+                        f"compiler_flags={package_info[package_name].get('compiler_flags', '')}"
+                    )
                     
         except Exception as e:
             if self.logger:
                 self.logger.warning(f"Could not retrieve package info from upstream: {e}")
  
         return package_info
+
+    def _parse_upstream_find_line(self, line: str) -> Optional[Dict[str, Any]]:
+        """Parse formatted `spack find` output line for upstream package information."""
+        parts = line.strip().split(':VERSION:')
+        if len(parts) != 2:
+            return None
+
+        package_name = parts[0]
+        rest = parts[1]
+
+        if ':VARIANTS:' not in rest or ':FLAGS:' not in rest or ':EXTERNAL:' not in rest:
+            return None
+
+        version_part, rest = rest.split(':VARIANTS:', 1)
+        variants_part, rest = rest.split(':FLAGS:', 1)
+        compiler_flags_part, external_part = rest.split(':EXTERNAL:', 1)
+
+        variants = re.sub(r"patches=[\w,]+", "", variants_part.strip()).strip()
+
+        return {
+            "name": package_name,
+            "version": version_part.strip(),
+            "variants": variants,
+            "compiler_flags": compiler_flags_part.strip(),
+            "is_external": external_part.strip().lower() == 'true',
+        }
+
+    def _get_metapackage_dependency_candidates(self, upstream_env_path: Path, metapackage_name: str) -> Dict[str, List[Dict[str, str]]]:
+        """Get concrete dependency candidates for a metapackage from upstream environment."""
+        candidates: Dict[str, List[Dict[str, str]]] = {}
+
+        try:
+            SPACK_STACK_DIR = os.path.abspath(os.path.join(upstream_env_path, "../../"))
+            result = self._run_spack_command([
+                '-e', str(upstream_env_path),
+                'find',
+                '--deps',
+                '--format', '{name}:VERSION:{version}:VARIANTS:{variants}:FLAGS:{compiler_flags}:EXTERNAL:{external}',
+                metapackage_name,
+            ], vars={"SPACK_STACK_DIR": SPACK_STACK_DIR})
+
+            if result.returncode != 0 or not result.stdout.strip():
+                return candidates
+
+            for line in result.stdout.strip().split('\n'):
+                parsed = self._parse_upstream_find_line(line)
+                if not parsed or parsed["is_external"]:
+                    continue
+
+                name = parsed["name"]
+                candidates.setdefault(name, []).append({
+                    "version": parsed["version"],
+                    "variants": parsed["variants"],
+                    "compiler_flags": parsed["compiler_flags"],
+                })
+
+        except Exception as e:
+            if self.logger:
+                self.logger.warning(f"Could not retrieve metapackage dependencies for {metapackage_name}: {e}")
+
+        return candidates
 
     def get_upstream_package_hashes(self, upstream_env_path: Path, package_name: str) -> List[Dict[str, str]]:
         """Get available concrete spec hashes for a package from upstream environment.

--- a/src/emcenvchainer/spack_manager.py
+++ b/src/emcenvchainer/spack_manager.py
@@ -37,7 +37,7 @@ class SpackManager:
         # Track packages whose recipes were retrieved from the remote Spack repository
         # during pending recipe processing for this environment creation.
         self.remote_recipes_added: List[str] = []
-        self._available_packages_cache: Optional[set[str]] = None
+        self._available_packages_cache: Dict[str, set[str]] = {}
         self.logger = None  # Will be initialized when environment directory is created
 
         assert self.spack_exe.exists(), "Spack executable not found"
@@ -911,11 +911,12 @@ class SpackManager:
 
         return version in available_versions
 
-    def check_package_exists(self, package_name: str) -> bool:
+    def check_package_exists(self, package_name: str, upstream_env_path: str) -> bool:
         """Check if a package exists in the current Spack installation.
 
         Args:
             package_name: Name of the package to check
+            upstream_env_path: Upstream environment path to use with `spack -e`
 
         Returns:
             True if package exists, False otherwise
@@ -924,27 +925,31 @@ class SpackManager:
         if not package_name:
             return False
 
-        available_packages = self._get_available_package_names()
+        available_packages = self._get_available_package_names(upstream_env_path)
         return package_name in available_packages
 
-    def _get_available_package_names(self) -> set[str]:
-        """Get installed package names from `spack find --format {name}`."""
-        if self._available_packages_cache is not None:
-            return self._available_packages_cache
+    def _get_available_package_names(self, upstream_env_path: str) -> set[str]:
+        """Get installed package names from `spack -e <env> find --format {name}`."""
+        if not upstream_env_path:
+            raise ValueError("upstream_env_path is required for package availability checks")
 
-        result = self._run_spack_command(['find', '--format', '{name}'])
+        cache_key = upstream_env_path
+        if cache_key in self._available_packages_cache:
+            return self._available_packages_cache[cache_key]
+
+        result = self._run_spack_command(['-e', upstream_env_path, 'find', '--format', '{name}'])
         if result.returncode != 0:
-            if self.logger:
-                self.logger.warning("Failed to list packages with `spack find --format {name}`")
-            self._available_packages_cache = set()
-            return self._available_packages_cache
+            error_msg = "Failed to list packages with `spack find --format {name}`"
+            if result.stderr:
+                error_msg += f": {result.stderr.strip()}"
+            raise RuntimeError(error_msg)
 
-        self._available_packages_cache = {
+        self._available_packages_cache[cache_key] = {
             line.strip()
             for line in result.stdout.splitlines()
             if line.strip()
         }
-        return self._available_packages_cache
+        return self._available_packages_cache[cache_key]
 
     def _get_remote_repo_info(self, base_url: str = None) -> tuple[str, str, str]:
         """Extract Git organization, repository name, and branch from config.

--- a/src/emcenvchainer/spack_manager.py
+++ b/src/emcenvchainer/spack_manager.py
@@ -933,11 +933,15 @@ class SpackManager:
         if not upstream_env_path:
             raise ValueError("upstream_env_path is required for package availability checks")
 
-        cache_key = upstream_env_path
+        # go from spack_env/install/ to spack_env/:
+        normalized_env_path = upstream_env_path.rstrip("/")
+        normalized_env_path = os.path.dirname(normalized_env_path)
+
+        cache_key = normalized_env_path
         if cache_key in self._available_packages_cache:
             return self._available_packages_cache[cache_key]
 
-        result = self._run_spack_command(['-e', upstream_env_path, 'find', '--format', '{name}'])
+        result = self._run_spack_command(['-e', normalized_env_path, 'find', '--format', '{name}'])
         if result.returncode != 0:
             error_msg = "Failed to list packages with `spack find --format {name}`"
             if result.stderr:

--- a/src/emcenvchainer/spack_manager.py
+++ b/src/emcenvchainer/spack_manager.py
@@ -933,15 +933,19 @@ class SpackManager:
         if not upstream_env_path:
             raise ValueError("upstream_env_path is required for package availability checks")
 
-        # go from spack_env/install/ to spack_env/:
         normalized_env_path = upstream_env_path.rstrip("/")
-        normalized_env_path = os.path.dirname(normalized_env_path)
+        if normalized_env_path.endswith("/install"):
+            normalized_env_path = os.path.dirname(normalized_env_path)
 
         cache_key = normalized_env_path
         if cache_key in self._available_packages_cache:
             return self._available_packages_cache[cache_key]
 
-        result = self._run_spack_command(['-e', normalized_env_path, 'find', '--format', '{name}'])
+        spack_stack_dir = os.path.abspath(os.path.join(normalized_env_path, "../../"))
+        result = self._run_spack_command(
+            ['-e', normalized_env_path, 'find', '--format', '{name}'],
+            vars={"SPACK_STACK_DIR": spack_stack_dir},
+        )
         if result.returncode != 0:
             error_msg = "Failed to list packages with `spack find --format {name}`"
             if result.stderr:

--- a/src/emcenvchainer/spack_manager.py
+++ b/src/emcenvchainer/spack_manager.py
@@ -37,6 +37,7 @@ class SpackManager:
         # Track packages whose recipes were retrieved from the remote Spack repository
         # during pending recipe processing for this environment creation.
         self.remote_recipes_added: List[str] = []
+        self._available_packages_cache: Optional[set[str]] = None
         self.logger = None  # Will be initialized when environment directory is created
 
         assert self.spack_exe.exists(), "Spack executable not found"
@@ -923,8 +924,27 @@ class SpackManager:
         if not package_name:
             return False
 
-        result = self._run_spack_command(['versions', '--safe', package_name])
-        return result.returncode == 0
+        available_packages = self._get_available_package_names()
+        return package_name in available_packages
+
+    def _get_available_package_names(self) -> set[str]:
+        """Get installed package names from `spack find --format {name}`."""
+        if self._available_packages_cache is not None:
+            return self._available_packages_cache
+
+        result = self._run_spack_command(['find', '--format', '{name}'])
+        if result.returncode != 0:
+            if self.logger:
+                self.logger.warning("Failed to list packages with `spack find --format {name}`")
+            self._available_packages_cache = set()
+            return self._available_packages_cache
+
+        self._available_packages_cache = {
+            line.strip()
+            for line in result.stdout.splitlines()
+            if line.strip()
+        }
+        return self._available_packages_cache
 
     def _get_remote_repo_info(self, base_url: str = None) -> tuple[str, str, str]:
         """Extract Git organization, repository name, and branch from config.

--- a/src/emcenvchainer/spack_manager.py
+++ b/src/emcenvchainer/spack_manager.py
@@ -910,6 +910,22 @@ class SpackManager:
 
         return version in available_versions
 
+    def check_package_exists(self, package_name: str) -> bool:
+        """Check if a package exists in the current Spack installation.
+
+        Args:
+            package_name: Name of the package to check
+
+        Returns:
+            True if package exists, False otherwise
+        """
+        package_name = package_name.strip()
+        if not package_name:
+            return False
+
+        result = self._run_spack_command(['versions', '--safe', package_name])
+        return result.returncode == 0
+
     def _get_remote_repo_info(self, base_url: str = None) -> tuple[str, str, str]:
         """Extract Git organization, repository name, and branch from config.
         

--- a/src/emcenvchainer/tui.py
+++ b/src/emcenvchainer/tui.py
@@ -1572,8 +1572,7 @@ class EmcEnvChainerTUI:
         if skipped_unavailable:
             unique_missing = sorted(set(skipped_unavailable))
             status_lines = [
-                f"Warning: {len(unique_missing)} package(s) omitted (not found in Spack).",
-                "Skipped: " + ", ".join(unique_missing),
+                f"Warning: {len(unique_missing)} package(s) not from Spack. Skipping: " + ", ".join(unique_missing),
             ]
 
         if not display_packages and not allow_additional_packages:

--- a/src/emcenvchainer/tui.py
+++ b/src/emcenvchainer/tui.py
@@ -1562,7 +1562,9 @@ class EmcEnvChainerTUI:
 
             package_name = str(pkg.get("name", "")).strip()
             if package_name not in exists_cache:
-                exists_cache[package_name] = self._is_package_available_for_env(spack_manager, package_name)
+                exists_cache[package_name] = self._is_package_available_for_env(
+                    spack_manager, package_name, upstream_path
+                )
 
             if not exists_cache[package_name]:
                 skipped_unavailable.append(package_name)
@@ -1664,7 +1666,9 @@ class EmcEnvChainerTUI:
 
         return selected_packages if selected_packages else None
 
-    def _is_package_available_for_env(self, spack_manager: SpackManager, package_name: str) -> bool:
+    def _is_package_available_for_env(
+        self, spack_manager: SpackManager, package_name: str, upstream_path: str
+    ) -> bool:
         """Check package availability, including pending custom recipe operations."""
         pending_recipes = getattr(spack_manager, "pending_recipes", {})
         if isinstance(pending_recipes, dict) and package_name in pending_recipes:
@@ -1682,7 +1686,7 @@ class EmcEnvChainerTUI:
                 if isinstance(item, dict) and item.get("package_name") == package_name:
                     return True
 
-        return bool(spack_manager.check_package_exists(package_name))
+        return bool(spack_manager.check_package_exists(package_name, upstream_path))
     
     def _get_package_specification(self, stdscr, pkg: Dict, spack_manager: SpackManager, upstream_path: str = None) -> Optional[Dict]:
         """Get detailed package specification (version, variants) from user.

--- a/src/emcenvchainer/tui.py
+++ b/src/emcenvchainer/tui.py
@@ -2,6 +2,8 @@
 
 import curses
 import os
+import shlex
+import subprocess
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple, Any
 
@@ -939,11 +941,17 @@ class EmcEnvChainerTUI:
         except Exception as e:
             print(f"Error running TUI: {e}")
 
-    def display_scrollable_text(self, stdscr, title: List[str], content: str):
+    def display_scrollable_text(
+        self,
+        stdscr,
+        title: List[str],
+        content: str,
+        editable_file_path: Optional[str] = None,
+        content_loader: Optional[Any] = None,
+    ):
         """Display scrollable text content."""
         stdscr.clear()
         height, width = stdscr.getmaxyx()
-        lines = content.split('\n')
         
         # Display title lines
         for i in range(len(title)):
@@ -958,6 +966,8 @@ class EmcEnvChainerTUI:
         
         # Add special note for Spack Concretize Output
         instruction_lines = ["Use UP/DOWN arrows to scroll, ENTER to continue..."]
+        if editable_file_path:
+            instruction_lines.insert(0, "Press 'e' to edit file and return to this screen.")
         if "Spack Concretize Output" in title:
             instruction_lines.append("Note: [^] indicates packages from the upstream environment(s)")
         
@@ -969,9 +979,16 @@ class EmcEnvChainerTUI:
         display_start_y = header_end_y + 1  # Add one line of spacing after header
         display_height = height - display_start_y - len(instruction_lines) - 2  # Leave room for instructions and spacing
         scroll_pos = 0
-        max_scroll = max(0, len(lines) - display_height)
         
         while True:
+            if content_loader:
+                content = content_loader()
+
+            lines = content.split('\n')
+            max_scroll = max(0, len(lines) - display_height)
+            if scroll_pos > max_scroll:
+                scroll_pos = max_scroll
+
             # Clear the content area
             for y in range(display_start_y, display_start_y + display_height):
                 stdscr.move(y, 0)
@@ -999,10 +1016,42 @@ class EmcEnvChainerTUI:
             
             if key == ord('\n') or key == ord('\r'):
                 break
+            elif key in [ord('e'), ord('E')] and editable_file_path:
+                edit_error = self._open_file_in_editor(stdscr, editable_file_path)
+                if edit_error:
+                    TUIMenu(stdscr, "Editor Error").display_info(edit_error)
             elif key == curses.KEY_UP and scroll_pos > 0:
                 scroll_pos -= 1
             elif key == curses.KEY_DOWN and scroll_pos < max_scroll:
                 scroll_pos += 1
+
+    def _open_file_in_editor(self, stdscr, file_path: str) -> Optional[str]:
+        """Open a file in an editor and restore curses mode when done."""
+        editor_cmd = os.environ.get("EDITOR", "").strip()
+
+        curses.endwin()
+        try:
+            if not editor_cmd:
+                print("$EDITOR is not set.")
+                editor_cmd = input("Enter editor command (e.g., vi, nano, 'code -w'): ").strip()
+                if not editor_cmd:
+                    return "No editor command provided. Set $EDITOR or provide a command when prompted."
+
+            cmd = shlex.split(editor_cmd)
+            if not cmd:
+                return "Invalid editor command."
+
+            cmd.append(file_path)
+            result = subprocess.run(cmd, check=False)
+            if result.returncode != 0:
+                return f"Editor exited with code {result.returncode}."
+
+            return None
+        except Exception as e:
+            return f"Failed to open editor: {e}"
+        finally:
+            stdscr.refresh()
+            curses.doupdate()
 
     def run_interactive_install(self, stdscr, spack_manager, env_path: str) -> bool:
         """Run spack install with live output, temporarily exiting curses mode.
@@ -1770,12 +1819,18 @@ class EmcEnvChainerTUI:
             self._generate_activate_script(env_path, upstream_path)
             
             # Concretize
-            with open(os.path.join(env_path, "spack.yaml"), "r") as f:
-                spack_yaml = f.read()
+            spack_yaml_path = os.path.join(env_path, "spack.yaml")
+
+            def _load_spack_yaml() -> str:
+                with open(spack_yaml_path, "r") as f:
+                    return f.read()
+
             self.display_scrollable_text(
                 stdscr,
                 [f"Environment created at: {env_path}", "Proceed with concretization?", "Make any manual changes to spack.yaml & package.py's now.", "spack.yaml:"],
-                spack_yaml
+                _load_spack_yaml(),
+                editable_file_path=spack_yaml_path,
+                content_loader=_load_spack_yaml,
             )
             menu.display_info("Concretizing environment...", wait_for_key=False)
             success, concretize_output = spack_manager.concretize_environment(env_path)

--- a/src/emcenvchainer/tui.py
+++ b/src/emcenvchainer/tui.py
@@ -1620,7 +1620,7 @@ class EmcEnvChainerTUI:
             warning_lines = [
                 "Warning: Skipping packages not found in Spack:",
                 ", ".join(unique_missing),
-                "These packages were not added to spack.yaml.",
+                "These packages will not be added to spack.yaml.",
             ]
             TUIMenu(stdscr, "Package Validation").display_info("\n".join(warning_lines))
 

--- a/src/emcenvchainer/tui.py
+++ b/src/emcenvchainer/tui.py
@@ -967,7 +967,7 @@ class EmcEnvChainerTUI:
         # Add special note for Spack Concretize Output
         instruction_lines = ["Use UP/DOWN arrows to scroll, ENTER to continue..."]
         if editable_file_path:
-            instruction_lines.insert(0, "Press 'e' to edit file and return to this screen.")
+            instruction_lines.insert(0, "Press 'e' to edit spack.yaml.")
         if "Spack Concretize Output" in title:
             instruction_lines.append("Note: [^] indicates packages from the upstream environment(s)")
         

--- a/src/emcenvchainer/tui.py
+++ b/src/emcenvchainer/tui.py
@@ -925,7 +925,9 @@ class EmcEnvChainerTUI:
         self.config = config
         self.platform = platform
         self.model_app_manager = ModelApplicationManager(
-            platform.config, platform.name
+            platform.config,
+            platform.name,
+            self.config.get_applications(),
         )
 
     def run(self):

--- a/src/emcenvchainer/tui.py
+++ b/src/emcenvchainer/tui.py
@@ -1548,14 +1548,41 @@ class EmcEnvChainerTUI:
         # Create display options for radio button menu
         options = []
         display_packages = []
+        status_lines: List[str] = []
+        exists_cache: Dict[str, bool] = {}
+        skipped_unavailable: List[str] = []
+
         for pkg in all_packages:
             # Skip ufs_common, cmake, and spack-stack metamodules (stack-*)
             if pkg["name"] in ["ufs_common", "cmake"] or pkg["name"].startswith("stack-"):
+                continue
+
+            package_name = str(pkg.get("name", "")).strip()
+            if package_name not in exists_cache:
+                exists_cache[package_name] = self._is_package_available_for_env(spack_manager, package_name)
+
+            if not exists_cache[package_name]:
+                skipped_unavailable.append(package_name)
                 continue
                 
             pkg_type = "📦"
             options.append(f"{pkg_type} {pkg['name']} (v{pkg['current_version']})")
             display_packages.append({"kind": "base", "pkg": pkg})
+
+        if skipped_unavailable:
+            unique_missing = sorted(set(skipped_unavailable))
+            status_lines = [
+                f"Warning: {len(unique_missing)} package(s) omitted (not found in Spack).",
+                "Skipped: " + ", ".join(unique_missing),
+            ]
+
+        if not display_packages and not allow_additional_packages:
+            menu = TUIMenu(stdscr, "No Supported Packages")
+            msg = "No packages from module files are available in Spack."
+            if status_lines:
+                msg += "\n\n" + "\n".join(status_lines)
+            menu.display_info(msg)
+            return []
 
         radio_menu = RadioButtonMenu(stdscr, "Select packages to update, modify, or lock from upstream")
 
@@ -1591,6 +1618,7 @@ class EmcEnvChainerTUI:
             options,
             extra_instructions=extra_instructions,
             key_actions=key_actions,
+            status_lines=status_lines,
         )
         
         if selected_indices is None:
@@ -1629,51 +1657,7 @@ class EmcEnvChainerTUI:
             ]
         )
 
-        selected_packages = self._filter_packages_available_in_spack(
-            stdscr,
-            selected_packages,
-            spack_manager,
-        )
-
         return selected_packages if selected_packages else None
-
-    def _filter_packages_available_in_spack(
-        self,
-        stdscr,
-        packages: List[Dict],
-        spack_manager: SpackManager,
-    ) -> List[Dict]:
-        """Keep only packages that exist in Spack and warn for skipped packages."""
-        if not packages:
-            return packages
-
-        filtered_packages = []
-        missing_packages = []
-        exists_cache: Dict[str, bool] = {}
-
-        for pkg in packages:
-            package_name = str(pkg.get("name", "")).strip()
-            if not package_name:
-                continue
-
-            if package_name not in exists_cache:
-                exists_cache[package_name] = self._is_package_available_for_env(spack_manager, package_name)
-
-            if exists_cache[package_name]:
-                filtered_packages.append(pkg)
-            else:
-                missing_packages.append(pkg)
-
-        if missing_packages:
-            unique_missing = sorted({pkg["name"] for pkg in missing_packages})
-            warning_lines = [
-                "Warning: Skipping packages not found in Spack:",
-                ", ".join(unique_missing),
-                "These packages will not be added to spack.yaml.",
-            ]
-            TUIMenu(stdscr, "Package Validation").display_info("\n".join(warning_lines))
-
-        return filtered_packages
 
     def _is_package_available_for_env(self, spack_manager: SpackManager, package_name: str) -> bool:
         """Check package availability, including pending custom recipe operations."""

--- a/src/emcenvchainer/tui.py
+++ b/src/emcenvchainer/tui.py
@@ -1580,7 +1580,71 @@ class EmcEnvChainerTUI:
             ]
         )
 
+        selected_packages = self._filter_packages_available_in_spack(
+            stdscr,
+            selected_packages,
+            spack_manager,
+        )
+
         return selected_packages if selected_packages else None
+
+    def _filter_packages_available_in_spack(
+        self,
+        stdscr,
+        packages: List[Dict],
+        spack_manager: SpackManager,
+    ) -> List[Dict]:
+        """Keep only packages that exist in Spack and warn for skipped packages."""
+        if not packages:
+            return packages
+
+        filtered_packages = []
+        missing_packages = []
+        exists_cache: Dict[str, bool] = {}
+
+        for pkg in packages:
+            package_name = str(pkg.get("name", "")).strip()
+            if not package_name:
+                continue
+
+            if package_name not in exists_cache:
+                exists_cache[package_name] = self._is_package_available_for_env(spack_manager, package_name)
+
+            if exists_cache[package_name]:
+                filtered_packages.append(pkg)
+            else:
+                missing_packages.append(pkg)
+
+        if missing_packages:
+            unique_missing = sorted({pkg["name"] for pkg in missing_packages})
+            warning_lines = [
+                "Warning: Skipping packages not found in Spack:",
+                ", ".join(unique_missing),
+                "These packages were not added to spack.yaml.",
+            ]
+            TUIMenu(stdscr, "Package Validation").display_info("\n".join(warning_lines))
+
+        return filtered_packages
+
+    def _is_package_available_for_env(self, spack_manager: SpackManager, package_name: str) -> bool:
+        """Check package availability, including pending custom recipe operations."""
+        pending_recipes = getattr(spack_manager, "pending_recipes", {})
+        if isinstance(pending_recipes, dict) and package_name in pending_recipes:
+            return True
+
+        pending_git_commits = getattr(spack_manager, "pending_git_commits", [])
+        if isinstance(pending_git_commits, list):
+            for item in pending_git_commits:
+                if isinstance(item, dict) and item.get("package_name") == package_name:
+                    return True
+
+        pending_checksums = getattr(spack_manager, "pending_checksums", [])
+        if isinstance(pending_checksums, list):
+            for item in pending_checksums:
+                if isinstance(item, dict) and item.get("package_name") == package_name:
+                    return True
+
+        return bool(spack_manager.check_package_exists(package_name))
     
     def _get_package_specification(self, stdscr, pkg: Dict, spack_manager: SpackManager, upstream_path: str = None) -> Optional[Dict]:
         """Get detailed package specification (version, variants) from user.

--- a/src/emcenvchainer/tui.py
+++ b/src/emcenvchainer/tui.py
@@ -1491,6 +1491,7 @@ class EmcEnvChainerTUI:
         # Combine dependencies and upgradable packages for selection
         all_packages = []
         upgradable_names = {pkg['name'] for pkg in upgradable_packages}
+        app_metapackage = selected_app.config.get("spack_metapackage", "")
         
         # Add upgradable packages first (these are preferred)
         for pkg in upgradable_packages:
@@ -1498,7 +1499,8 @@ class EmcEnvChainerTUI:
                 "name": pkg['name'],
                 "current_version": pkg['version'],
                 "type": "upgradable", 
-                "source": pkg
+                "source": pkg,
+                "application_metapackage": app_metapackage,
             })
         
         # Add dependencies only if they're not already available as upgradable packages
@@ -1508,7 +1510,8 @@ class EmcEnvChainerTUI:
                     "name": dep['name'],
                     "current_version": dep['version'],
                     "type": "dependency",
-                    "source": dep
+                    "source": dep,
+                    "application_metapackage": app_metapackage,
                 })
         
         if not all_packages:
@@ -1645,6 +1648,9 @@ class EmcEnvChainerTUI:
                 # Get package specification with version and variants
                 spec = self._get_package_specification(stdscr, pkg, spack_manager, upstream_path)
                 if spec:
+                    metapackage = pkg.get("application_metapackage")
+                    if metapackage:
+                        spec["application_metapackage"] = metapackage
                     selected_packages.append(spec)
 
         # Preserve existing behavior: unselected base packages are still included unchanged.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ class TestConfig:
         config = Config()
         assert config._config is not None
         assert "platforms" in config._config
+        assert "applications" in config._config
     
     def test_builtin_platforms(self):
         """Test that built-in platforms are available."""
@@ -51,3 +52,11 @@ class TestConfig:
         # Test model applications
         model_apps = ursa_config["model_applications"]
         assert "ufs_weather_model" in model_apps
+        assert "global_workflow" in model_apps
+
+        # Test shared application configuration
+        applications = config.get_applications()
+        assert "ufs_weather_model" in applications
+        assert "common_module_url" in applications["ufs_weather_model"]
+        assert "global_workflow" in applications
+        assert "package_versions_url" in applications["global_workflow"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,5 +58,7 @@ class TestConfig:
         applications = config.get_applications()
         assert "ufs_weather_model" in applications
         assert "common_module_url" in applications["ufs_weather_model"]
+        assert applications["ufs_weather_model"]["spack_metapackage"] == "ufs-weather-model-env"
         assert "global_workflow" in applications
         assert "package_versions_url" in applications["global_workflow"]
+        assert applications["global_workflow"]["spack_metapackage"] == "global-workflow-env"

--- a/tests/test_model_apps.py
+++ b/tests/test_model_apps.py
@@ -94,6 +94,33 @@ load("cmake/3.23.1")
         assert packages == []
 
     @patch('requests.get')
+    def test_get_upgradable_packages_shell_exports_success(self, mock_get):
+        """Test parsing upgradable packages from shell export version files."""
+        mock_response = Mock()
+        mock_response.text = '''#! /usr/bin/env bash
+export hdf5_ver=1.14.3
+export netcdf_c_ver=4.9.2
+export py_pyyaml_ver=6.0.2
+export stack_python_ver=3.11.7
+'''
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        config = {
+            "package_versions_url": "https://example.com/spack.ver",
+            "package_versions_format": "shell_exports",
+        }
+
+        app = ModelApplication("global_workflow", config, "ursa")
+        packages = app.get_upgradable_packages()
+
+        package_versions = {pkg['name']: pkg['version'] for pkg in packages}
+        assert package_versions['hdf5'] == "1.14.3"
+        assert package_versions['netcdf-c'] == "4.9.2"
+        assert package_versions['py-pyyaml'] == "6.0.2"
+        assert 'stack-python' not in package_versions
+
+    @patch('requests.get')
     def test_extract_install_path_success(self, mock_get):
         """Test successful extraction of install path from module file."""
         # Mock response for module file with install path
@@ -287,18 +314,24 @@ class TestModelApplicationManager:
         platform_config = {
             "model_applications": {
                 "ufs_weather_model": {
-                    "name": "UFS Weather Model",
                     "module_url_templates": ["https://example.com/ufs.lua"]
                 }
             }
         }
+        applications_config = {
+            "ufs_weather_model": {
+                "name": "UFS Weather Model",
+                "common_module_url": "https://example.com/ufs_common.lua"
+            }
+        }
         
-        manager = ModelApplicationManager(platform_config, "hera")
+        manager = ModelApplicationManager(platform_config, "hera", applications_config)
         
         assert manager.platform_config == platform_config
         assert manager.platform_name == "hera"
         assert len(manager.applications) == 1
         assert manager.applications[0].name == "ufs_weather_model"
+        assert manager.applications[0].config["common_module_url"] == "https://example.com/ufs_common.lua"
 
     @patch('requests.get')
     def test_full_workflow_with_upgradable_packages(self, mock_get):
@@ -328,18 +361,22 @@ load("hdf5/1.10.8")
         platform_config = {
             "model_applications": {
                 "ufs_weather_model": {
-                    "name": "UFS Weather Model",
                     "module_url_templates": [
                         "https://example.com/ufs_hera.intel.lua",
                         "https://example.com/ufs_hera.gnu.lua"
                     ],
-                    "common_module_url": "https://example.com/ufs_common.lua",
                     "install_path_regex": r'setenv\("UFS_WEATHER_MODEL_ROOT",\s*"([^"]+)"\)'
                 }
             }
         }
+        applications_config = {
+            "ufs_weather_model": {
+                "name": "UFS Weather Model",
+                "common_module_url": "https://example.com/ufs_common.lua"
+            }
+        }
         
-        manager = ModelApplicationManager(platform_config, "hera")
+        manager = ModelApplicationManager(platform_config, "hera", applications_config)
         app = manager.applications[0]
         
         # Test module URL choices

--- a/tests/test_spack_manager.py
+++ b/tests/test_spack_manager.py
@@ -317,31 +317,37 @@ class TestSpackManager:
         mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = "hdf5\nnetcdf-c\ncmake\n"
+        upstream_install_path = "/path/to/spack-stack-1.2.3/envs/testenv/install/"
 
         with patch.object(spack_manager, '_run_spack_command', return_value=mock_result):
-            assert spack_manager.check_package_exists("hdf5", "/path/to/upstream/env") is True
+            assert spack_manager.check_package_exists("hdf5", upstream_install_path) is True
 
     def test_check_package_exists_not_found(self, spack_manager):
         """Test package existence check when package does not exist."""
         mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = "hdf5\nnetcdf-c\ncmake\n"
+        upstream_install_path = "/path/to/spack-stack-1.2.3/envs/testenv/install/"
 
         with patch.object(spack_manager, '_run_spack_command', return_value=mock_result):
-            assert spack_manager.check_package_exists("not-a-real-package", "/path/to/upstream/env") is False
+            assert spack_manager.check_package_exists("not-a-real-package", upstream_install_path) is False
 
     def test_check_package_exists_uses_cached_find_results(self, spack_manager):
         """Test package existence checks use cached package list from a single find call."""
         mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stdout = "hdf5\nnetcdf-c\n"
+        upstream_install_path = "/path/to/spack-stack-1.2.3/envs/testenv/install/"
 
         with patch.object(spack_manager, '_run_spack_command', return_value=mock_result) as mock_run:
-            assert spack_manager.check_package_exists("hdf5", "/path/to/upstream/env") is True
-            assert spack_manager.check_package_exists("netcdf-c", "/path/to/upstream/env") is True
-            assert spack_manager.check_package_exists("esmf", "/path/to/upstream/env") is False
+            assert spack_manager.check_package_exists("hdf5", upstream_install_path) is True
+            assert spack_manager.check_package_exists("netcdf-c", upstream_install_path) is True
+            assert spack_manager.check_package_exists("esmf", upstream_install_path) is False
 
-            mock_run.assert_called_once_with(['-e', '/path/to/upstream/env', 'find', '--format', '{name}'])
+            mock_run.assert_called_once_with(
+                ['-e', '/path/to/spack-stack-1.2.3/envs/testenv', 'find', '--format', '{name}'],
+                vars={'SPACK_STACK_DIR': '/path/to/spack-stack-1.2.3'},
+            )
 
     def test_check_package_exists_normalizes_install_path_to_env(self, spack_manager):
         """Test install path input is normalized to the parent env path for spack -e."""
@@ -353,7 +359,7 @@ class TestSpackManager:
             assert (
                 spack_manager.check_package_exists(
                     "hdf5",
-                    "/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/",
+                    "/path/to/spack-stack-1.2.3/envs/testenv/install/",
                 )
                 is True
             )
@@ -361,11 +367,12 @@ class TestSpackManager:
             mock_run.assert_called_once_with(
                 [
                     '-e',
-                    '/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1',
+                    '/path/to/spack-stack-1.2.3/envs/testenv',
                     'find',
                     '--format',
                     '{name}',
-                ]
+                ],
+                vars={'SPACK_STACK_DIR': '/path/to/spack-stack-1.2.3'},
             )
 
     def test_check_package_exists_raises_without_upstream_path(self, spack_manager):
@@ -382,7 +389,7 @@ class TestSpackManager:
 
         with patch.object(spack_manager, '_run_spack_command', return_value=mock_result):
             with pytest.raises(RuntimeError, match="Failed to list packages"):
-                spack_manager.check_package_exists("hdf5", "/path/to/upstream/env")
+                spack_manager.check_package_exists("hdf5", "/path/to/spack-stack-1.2.3/envs/testenv/install/modulefiles/Core/")
     
     @patch('pathlib.Path.mkdir')
     @patch('builtins.open', new_callable=mock_open)

--- a/tests/test_spack_manager.py
+++ b/tests/test_spack_manager.py
@@ -319,7 +319,7 @@ class TestSpackManager:
         mock_result.stdout = "hdf5\nnetcdf-c\ncmake\n"
 
         with patch.object(spack_manager, '_run_spack_command', return_value=mock_result):
-            assert spack_manager.check_package_exists("hdf5") is True
+            assert spack_manager.check_package_exists("hdf5", "/path/to/upstream/env") is True
 
     def test_check_package_exists_not_found(self, spack_manager):
         """Test package existence check when package does not exist."""
@@ -328,7 +328,7 @@ class TestSpackManager:
         mock_result.stdout = "hdf5\nnetcdf-c\ncmake\n"
 
         with patch.object(spack_manager, '_run_spack_command', return_value=mock_result):
-            assert spack_manager.check_package_exists("not-a-real-package") is False
+            assert spack_manager.check_package_exists("not-a-real-package", "/path/to/upstream/env") is False
 
     def test_check_package_exists_uses_cached_find_results(self, spack_manager):
         """Test package existence checks use cached package list from a single find call."""
@@ -337,11 +337,27 @@ class TestSpackManager:
         mock_result.stdout = "hdf5\nnetcdf-c\n"
 
         with patch.object(spack_manager, '_run_spack_command', return_value=mock_result) as mock_run:
-            assert spack_manager.check_package_exists("hdf5") is True
-            assert spack_manager.check_package_exists("netcdf-c") is True
-            assert spack_manager.check_package_exists("esmf") is False
+            assert spack_manager.check_package_exists("hdf5", "/path/to/upstream/env") is True
+            assert spack_manager.check_package_exists("netcdf-c", "/path/to/upstream/env") is True
+            assert spack_manager.check_package_exists("esmf", "/path/to/upstream/env") is False
 
-            mock_run.assert_called_once_with(['find', '--format', '{name}'])
+            mock_run.assert_called_once_with(['-e', '/path/to/upstream/env', 'find', '--format', '{name}'])
+
+    def test_check_package_exists_raises_without_upstream_path(self, spack_manager):
+        """Test package existence check fails fast when upstream path is missing."""
+        with pytest.raises(ValueError, match="upstream_env_path is required"):
+            spack_manager.check_package_exists("hdf5", "")
+
+    def test_check_package_exists_raises_when_find_fails(self, spack_manager):
+        """Test package existence check fails fast when spack find command fails."""
+        mock_result = Mock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "spack find failed"
+
+        with patch.object(spack_manager, '_run_spack_command', return_value=mock_result):
+            with pytest.raises(RuntimeError, match="Failed to list packages"):
+                spack_manager.check_package_exists("hdf5", "/path/to/upstream/env")
     
     @patch('pathlib.Path.mkdir')
     @patch('builtins.open', new_callable=mock_open)

--- a/tests/test_spack_manager.py
+++ b/tests/test_spack_manager.py
@@ -2460,6 +2460,65 @@ def func(): pass
         mock_run.side_effect = RuntimeError("boom")
         assert spack_manager._get_upstream_package_info(tmp_path, [{'name':'pkg'}]) == {}
 
+    @patch.object(SpackManager, '_run_spack_command')
+    def test__get_upstream_package_info_metapackage_tie_breaker(
+        self, mock_run, spack_manager, tmp_path
+    ):
+        """Should prefer duplicate package spec matching metapackage dependency output."""
+        packages = [{
+            'name': 'hdf5',
+            'application_metapackage': 'global-workflow-env',
+        }]
+
+        all_packages_result = CompletedProcess(
+            args=[], returncode=0,
+            stdout=(
+                'hdf5:VERSION:1.14.0:VARIANTS:+mpi:FLAGS::EXTERNAL:False\n'
+                'hdf5:VERSION:1.12.2:VARIANTS:~mpi:FLAGS::EXTERNAL:False\n'
+            )
+        )
+        deps_result = CompletedProcess(
+            args=[], returncode=0,
+            stdout='hdf5:VERSION:1.14.0:VARIANTS:+mpi:FLAGS::EXTERNAL:False\n'
+        )
+
+        # First call is metapackage deps query, second call is full env package query.
+        mock_run.side_effect = [deps_result, all_packages_result]
+
+        info = spack_manager._get_upstream_package_info(tmp_path, packages)
+
+        assert info['hdf5']['version'] == '1.14.0'
+        assert info['hdf5']['variants'] == '+mpi'
+
+    @patch.object(SpackManager, '_run_spack_command')
+    def test__get_upstream_package_info_current_version_overrides_metapackage_tie_breaker(
+        self, mock_run, spack_manager, tmp_path
+    ):
+        """current_version should still override version even when tie-breaker data exists."""
+        packages = [{
+            'name': 'hdf5',
+            'current_version': '1.12.2',
+            'application_metapackage': 'global-workflow-env',
+        }]
+
+        all_packages_result = CompletedProcess(
+            args=[], returncode=0,
+            stdout=(
+                'hdf5:VERSION:1.14.0:VARIANTS:+mpi:FLAGS::EXTERNAL:False\n'
+                'hdf5:VERSION:1.12.2:VARIANTS:~mpi:FLAGS::EXTERNAL:False\n'
+            )
+        )
+        deps_result = CompletedProcess(
+            args=[], returncode=0,
+            stdout='hdf5:VERSION:1.14.0:VARIANTS:+mpi:FLAGS::EXTERNAL:False\n'
+        )
+
+        mock_run.side_effect = [deps_result, all_packages_result]
+
+        info = spack_manager._get_upstream_package_info(tmp_path, packages)
+
+        assert info['hdf5']['version'] == '1.12.2'
+
     @patch.object(SpackManager, '_get_upstream_package_info', return_value={})
     def test__create_spack_yaml_definitions_branch(self, mock_upstream, spack_manager, tmp_path):
         """When 'definitions' exist, packages go into definitions->packages."""

--- a/tests/test_spack_manager.py
+++ b/tests/test_spack_manager.py
@@ -316,6 +316,7 @@ class TestSpackManager:
         """Test package existence check when package exists."""
         mock_result = Mock()
         mock_result.returncode = 0
+        mock_result.stdout = "hdf5\nnetcdf-c\ncmake\n"
 
         with patch.object(spack_manager, '_run_spack_command', return_value=mock_result):
             assert spack_manager.check_package_exists("hdf5") is True
@@ -323,10 +324,24 @@ class TestSpackManager:
     def test_check_package_exists_not_found(self, spack_manager):
         """Test package existence check when package does not exist."""
         mock_result = Mock()
-        mock_result.returncode = 1
+        mock_result.returncode = 0
+        mock_result.stdout = "hdf5\nnetcdf-c\ncmake\n"
 
         with patch.object(spack_manager, '_run_spack_command', return_value=mock_result):
             assert spack_manager.check_package_exists("not-a-real-package") is False
+
+    def test_check_package_exists_uses_cached_find_results(self, spack_manager):
+        """Test package existence checks use cached package list from a single find call."""
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = "hdf5\nnetcdf-c\n"
+
+        with patch.object(spack_manager, '_run_spack_command', return_value=mock_result) as mock_run:
+            assert spack_manager.check_package_exists("hdf5") is True
+            assert spack_manager.check_package_exists("netcdf-c") is True
+            assert spack_manager.check_package_exists("esmf") is False
+
+            mock_run.assert_called_once_with(['find', '--format', '{name}'])
     
     @patch('pathlib.Path.mkdir')
     @patch('builtins.open', new_callable=mock_open)

--- a/tests/test_spack_manager.py
+++ b/tests/test_spack_manager.py
@@ -343,6 +343,31 @@ class TestSpackManager:
 
             mock_run.assert_called_once_with(['-e', '/path/to/upstream/env', 'find', '--format', '{name}'])
 
+    def test_check_package_exists_normalizes_install_path_to_env(self, spack_manager):
+        """Test install path input is normalized to the parent env path for spack -e."""
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = "hdf5\n"
+
+        with patch.object(spack_manager, '_run_spack_command', return_value=mock_result) as mock_run:
+            assert (
+                spack_manager.check_package_exists(
+                    "hdf5",
+                    "/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/",
+                )
+                is True
+            )
+
+            mock_run.assert_called_once_with(
+                [
+                    '-e',
+                    '/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1',
+                    'find',
+                    '--format',
+                    '{name}',
+                ]
+            )
+
     def test_check_package_exists_raises_without_upstream_path(self, spack_manager):
         """Test package existence check fails fast when upstream path is missing."""
         with pytest.raises(ValueError, match="upstream_env_path is required"):

--- a/tests/test_spack_manager.py
+++ b/tests/test_spack_manager.py
@@ -311,6 +311,22 @@ class TestSpackManager:
         with patch.object(spack_manager, '_run_spack_command', return_value=mock_result):
             result = spack_manager.check_package_version_exists("nonexistent-pkg", "1.0.0")
             assert result is False
+
+    def test_check_package_exists_success(self, spack_manager):
+        """Test package existence check when package exists."""
+        mock_result = Mock()
+        mock_result.returncode = 0
+
+        with patch.object(spack_manager, '_run_spack_command', return_value=mock_result):
+            assert spack_manager.check_package_exists("hdf5") is True
+
+    def test_check_package_exists_not_found(self, spack_manager):
+        """Test package existence check when package does not exist."""
+        mock_result = Mock()
+        mock_result.returncode = 1
+
+        with patch.object(spack_manager, '_run_spack_command', return_value=mock_result):
+            assert spack_manager.check_package_exists("not-a-real-package") is False
     
     @patch('pathlib.Path.mkdir')
     @patch('builtins.open', new_callable=mock_open)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -2263,6 +2263,45 @@ class TestEmcEnvChainerTUI:
         assert result is not None
         assert len(result) == 1
         assert result[0]["name"] == "netcdf-c"
+
+    @patch('emcenvchainer.tui.TUIMenu')
+    @patch('emcenvchainer.tui.RadioButtonMenu')
+    def test_select_packages_with_radio_buttons_skips_unknown_spack_packages(self, mock_radio_class, mock_menu_class, tui_app, mock_stdscr):
+        """Test that packages not found in Spack are filtered out with a warning."""
+        mock_radio = Mock()
+        mock_radio_class.return_value = mock_radio
+        mock_radio.display_menu.return_value = [0, 1]
+
+        mock_menu = Mock()
+        mock_menu_class.return_value = mock_menu
+
+        mock_spack_manager = Mock()
+        mock_spack_manager.pending_recipes = {}
+        mock_spack_manager.pending_git_commits = []
+        mock_spack_manager.pending_checksums = []
+        mock_spack_manager.check_package_exists.side_effect = lambda name: name != "external-tool"
+
+        mock_app = Mock()
+
+        all_packages = [
+            {"name": "netcdf-c", "current_version": "4.9.0", "type": "upgradable"},
+            {"name": "external-tool", "current_version": "1.0.0", "type": "dependency"}
+        ]
+
+        specs = [
+            {"name": "netcdf-c", "version": "4.9.0"},
+            {"name": "external-tool", "version": "1.0.0"}
+        ]
+
+        with patch.object(tui_app, '_get_package_specification', side_effect=specs):
+            result = tui_app._select_packages_with_radio_buttons(mock_stdscr, all_packages, mock_app, mock_spack_manager)
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["name"] == "netcdf-c"
+
+        warning_calls = [call for call in mock_menu.display_info.call_args_list if "Skipping packages not found in Spack" in str(call)]
+        assert len(warning_calls) == 1
     
     @patch('emcenvchainer.tui.RadioButtonMenu')
     def test_select_packages_with_radio_buttons_partial_selection(self, mock_radio_class, tui_app, mock_stdscr):

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -2298,16 +2298,12 @@ class TestEmcEnvChainerTUI:
         assert len(result) == 1
         assert result[0]["name"] == "netcdf-c"
 
-    @patch('emcenvchainer.tui.TUIMenu')
     @patch('emcenvchainer.tui.RadioButtonMenu')
-    def test_select_packages_with_radio_buttons_skips_unknown_spack_packages(self, mock_radio_class, mock_menu_class, tui_app, mock_stdscr):
-        """Test that packages not found in Spack are filtered out with a warning."""
+    def test_select_packages_with_radio_buttons_skips_unknown_spack_packages(self, mock_radio_class, tui_app, mock_stdscr):
+        """Test that packages not found in Spack are omitted before checklist display."""
         mock_radio = Mock()
         mock_radio_class.return_value = mock_radio
-        mock_radio.display_menu.return_value = [0, 1]
-
-        mock_menu = Mock()
-        mock_menu_class.return_value = mock_menu
+        mock_radio.display_menu.return_value = [0]
 
         mock_spack_manager = Mock()
         mock_spack_manager.pending_recipes = {}
@@ -2334,8 +2330,15 @@ class TestEmcEnvChainerTUI:
         assert len(result) == 1
         assert result[0]["name"] == "netcdf-c"
 
-        warning_calls = [call for call in mock_menu.display_info.call_args_list if "Skipping packages not found in Spack" in str(call)]
-        assert len(warning_calls) == 1
+        options = mock_radio.display_menu.call_args[0][0]
+        assert len(options) == 1
+        assert "netcdf-c" in options[0]
+        assert "external-tool" not in str(options)
+
+        status_lines = mock_radio.display_menu.call_args[1]["status_lines"]
+        assert status_lines is not None
+        assert any("omitted" in line.lower() for line in status_lines)
+        assert any("external-tool" in line for line in status_lines)
     
     @patch('emcenvchainer.tui.RadioButtonMenu')
     def test_select_packages_with_radio_buttons_partial_selection(self, mock_radio_class, tui_app, mock_stdscr):
@@ -2386,12 +2389,15 @@ class TestEmcEnvChainerTUI:
         # Verify RadioButtonMenu was created with correct title
         mock_radio_class.assert_called_once_with(mock_stdscr, "Select packages to update, modify, or lock from upstream")
     
+    @patch('emcenvchainer.tui.TUIMenu')
     @patch('emcenvchainer.tui.RadioButtonMenu')
-    def test_select_packages_with_radio_buttons_empty_list_after_filtering(self, mock_radio_class, tui_app, mock_stdscr):
+    def test_select_packages_with_radio_buttons_empty_list_after_filtering(self, mock_radio_class, mock_menu_class, tui_app, mock_stdscr):
         """Test when all packages are filtered out."""
         mock_radio = Mock()
         mock_radio_class.return_value = mock_radio
-        mock_radio.display_menu.return_value = []
+
+        mock_menu = Mock()
+        mock_menu_class.return_value = mock_menu
         
         mock_spack_manager = Mock()
         mock_app = Mock()
@@ -2406,9 +2412,9 @@ class TestEmcEnvChainerTUI:
         with patch.object(tui_app, '_get_package_specification', return_value=None):
             result = tui_app._select_packages_with_radio_buttons(mock_stdscr, all_packages, mock_app, mock_spack_manager)
         
-        # Should still work with empty options list
-        options = mock_radio.display_menu.call_args[0][0]
-        assert len(options) == 0
+        # Should return early without showing checklist
+        mock_radio.display_menu.assert_not_called()
+        mock_menu.display_info.assert_called_once()
         assert result == []
 
     @patch('emcenvchainer.tui.PackageSpecDialog')

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -869,6 +869,7 @@ class TestEmcEnvChainerTUI:
         """Create a mock Config object."""
         config = Mock(spec=Config)
         config.get.return_value = {"test": "value"}
+        config.get_applications.return_value = {}
         return config
     
     @pytest.fixture
@@ -3849,6 +3850,7 @@ class TestTUIIntegration:
         """Test that TUI components work together."""
         # Create mock objects
         mock_config = Mock(spec=Config)
+        mock_config.get_applications.return_value = {}
         mock_platform = Mock(spec=Platform)
         mock_platform.name = "test-platform"
         mock_platform.config = {"test": "config"}

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -2037,6 +2037,40 @@ class TestEmcEnvChainerTUI:
         # Should have only dependencies
         assert len(captured_packages) == 2
         assert all(p["type"] == "dependency" for p in captured_packages)
+
+    @patch('emcenvchainer.tui.TUIMenu')
+    def test_get_packages_from_model_app_adds_application_metapackage_metadata(self, mock_menu_class, tui_app, mock_stdscr):
+        """Test model app packages include application metapackage metadata for tie-break logic."""
+        mock_menu = Mock()
+        mock_menu_class.return_value = mock_menu
+        mock_spack_manager = Mock()
+
+        mock_app = Mock()
+        mock_app.config = {"spack_metapackage": "global-workflow-env"}
+        mock_app.parse_dependencies.return_value = [
+            {"name": "hdf5", "version": "1.14.0"}
+        ]
+        mock_app.get_upgradable_packages.return_value = []
+
+        installation = {
+            "type": "model_application",
+            "name": "test-app",
+            "application": mock_app,
+            "selected_module_url": None
+        }
+
+        captured_packages = None
+
+        def capture_packages(stdscr, packages, app, manager, upstream_path=None, allow_additional_packages=False):
+            nonlocal captured_packages
+            captured_packages = packages
+            return []
+
+        with patch.object(tui_app, '_select_packages_with_radio_buttons', side_effect=capture_packages):
+            tui_app._get_packages_from_model_app(mock_stdscr, installation, mock_spack_manager)
+
+        assert captured_packages is not None
+        assert captured_packages[0]["application_metapackage"] == "global-workflow-env"
     
     @patch('emcenvchainer.tui.TUIMenu')
     def test_get_packages_from_model_app_cancelled(self, mock_menu_class, tui_app, mock_stdscr):

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -2343,7 +2343,9 @@ class TestEmcEnvChainerTUI:
         mock_spack_manager.pending_recipes = {}
         mock_spack_manager.pending_git_commits = []
         mock_spack_manager.pending_checksums = []
-        mock_spack_manager.check_package_exists.side_effect = lambda name: name != "external-tool"
+        mock_spack_manager.check_package_exists.side_effect = (
+            lambda name, upstream_path: name != "external-tool"
+        )
 
         mock_app = Mock()
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -2337,7 +2337,8 @@ class TestEmcEnvChainerTUI:
 
         status_lines = mock_radio.display_menu.call_args[1]["status_lines"]
         assert status_lines is not None
-        assert any("omitted" in line.lower() for line in status_lines)
+        assert any("not from spack" in line.lower() for line in status_lines)
+        assert any("skipping:" in line.lower() for line in status_lines)
         assert any("external-tool" in line for line in status_lines)
     
     @patch('emcenvchainer.tui.RadioButtonMenu')

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -947,6 +947,40 @@ class TestEmcEnvChainerTUI:
         assert mock_stdscr.clear.called
         assert mock_stdscr.addstr.called
         assert mock_stdscr.refresh.called
+
+    def test_display_scrollable_text_edit_hotkey_opens_editor(self, tui_app, mock_stdscr):
+        """Test that pressing 'e' opens editor and returns to same screen."""
+        title = ["Environment created", "spack.yaml:"]
+        content = "spack:\n  specs: []"
+
+        mock_stdscr.getch.side_effect = [ord('e'), ord('\n')]
+
+        with patch.object(tui_app, '_open_file_in_editor', return_value=None) as mock_open_editor:
+            tui_app.display_scrollable_text(
+                mock_stdscr,
+                title,
+                content,
+                editable_file_path="/tmp/spack.yaml",
+            )
+
+        mock_open_editor.assert_called_once_with(mock_stdscr, "/tmp/spack.yaml")
+
+    @patch('curses.endwin')
+    @patch('curses.doupdate')
+    @patch('subprocess.run')
+    def test_open_file_in_editor_prompts_when_editor_unset(self, mock_run, mock_doupdate, mock_endwin, tui_app, mock_stdscr):
+        """Test editor prompt fallback when $EDITOR is not set."""
+        mock_run.return_value = Mock(returncode=0)
+
+        with patch.dict('os.environ', {}, clear=True):
+            with patch('builtins.input', return_value='nano'):
+                result = tui_app._open_file_in_editor(mock_stdscr, '/tmp/spack.yaml')
+
+        assert result is None
+        mock_run.assert_called_once_with(['nano', '/tmp/spack.yaml'], check=False)
+        mock_endwin.assert_called_once()
+        mock_stdscr.refresh.assert_called()
+        mock_doupdate.assert_called_once()
     
     def test_run_interactive_install_success(self, tui_app, mock_stdscr):
         """Test successful interactive install."""


### PR DESCRIPTION
This PR:
 - adds support for Global Workflow
 - adds the option to edit spack.yaml with $EDITOR
 - adds automatic filtering out of packages not provided by Spack (this will probably need refinement, especially for cases where the package name reflected in the module hierarchy is not the same as the Spack package name, like ecmwf-atlas <-> atlas)
 - adds nicer "tie breaker" handling of which duplicate upstream spec to encode into soft package preferences (based on model metapackage deps)
 - refactors the application configuration to hopefully make it easier to add others